### PR TITLE
exportLabel is added to all Config Files

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ For every key in the JSON object, provide a detailed description by creating the
     [
       {  
         id: String,                           - required 
-        label: String,                        - optional 
+        label: String,                        - optional
+        exportLabel: String,                  - optional 
         sortable: Boolean,                    - optional
         hidden: Boolean,                      - optional
         externalLink: Boolean,                - optional
@@ -24,6 +25,8 @@ For every key in the JSON object, provide a detailed description by creating the
   <b>id</b>: The ID name used to describe this column from FNL API.
 
   <b>label</b>: Column display name that will appear in the table as the column header. If label is not present, a capitalized and spaced version of id will be used.
+
+  <b>exportLabel</b>: Column label shown on the exported file header. If not present, camelCase value from id field will be used. Camel case will also be applied to exportLabel value.
 
   <b>hidden</b>: If true, column will not be shown in the table. Downloaded data will still include columns that are hidden.
 

--- a/front-end/page_evidence/CnvByGene_Config.json
+++ b/front-end/page_evidence/CnvByGene_Config.json
@@ -10,7 +10,7 @@
   {
     "id": "targetFromSourceId",
     "label": "Gene Ensembl ID",
-    "exportLabel": "geneEnsemblID",
+    "exportLabel": "geneEnsemblId",
     "hidden": true,
     "chopFieldName": "targetFromSourceId"
   },

--- a/front-end/page_evidence/CnvByGene_Config.json
+++ b/front-end/page_evidence/CnvByGene_Config.json
@@ -2,6 +2,7 @@
   {
     "id": "geneSymbol",
     "label": "Target",
+    "exportLabel": "target",
     "sortable": true,
     "internalLink": true,
     "chopFieldName": "Gene_symbol"
@@ -9,6 +10,7 @@
   {
     "id": "targetFromSourceId",
     "label": "Gene Ensembl ID",
+    "exportLabel": "geneEnsemblID",
     "hidden": true,
     "chopFieldName": "targetFromSourceId"
   },
@@ -40,6 +42,7 @@
   {
     "id": "totalAlterationsOverPatientsInDataset",
     "label": "Total alterations / Subjects in dataset",
+    "exportLabel": "totalAlterationsOverSubjectsInDataset",
     "sortable": true,
     "chopFieldName": "Total_alterations_over_Patients_in_dataset"
   },
@@ -100,6 +103,7 @@
   {
     "id": "diseaseFromSourceMappedId",
     "label": "EFO",
+    "exportLabel": "efo",
     "hidden": true,
     "chopFieldName": "diseaseFromSourceMappedId"
   },

--- a/front-end/page_evidence/CnvByGene_Config.json
+++ b/front-end/page_evidence/CnvByGene_Config.json
@@ -1,8 +1,7 @@
 [
   {
     "id": "geneSymbol",
-    "label": "Target",
-    "exportLabel": "target",
+    "label": "Gene symbol",
     "sortable": true,
     "internalLink": true,
     "chopFieldName": "Gene_symbol"

--- a/front-end/page_evidence/CnvByGene_Config.json
+++ b/front-end/page_evidence/CnvByGene_Config.json
@@ -17,24 +17,28 @@
   {
     "id": "variantType",
     "label": "Variant type",
+    "exportLabel": "variantType",
     "sortable": true,
     "chopFieldName": "Variant_type"
   },
   {
     "id": "variantCategory",
     "label": "Variant category",
+    "exportLabel": "variantCategory",
     "sortable": true,
     "chopFieldName": "Variant_category"
   },
   {
     "id": "dataset",
     "label": "Dataset",
+    "exportLabel": "dataset",
     "sortable": true,
     "chopFieldName": "Dataset"
   },
   {
     "id": "Disease",
     "label": "Disease",
+    "exportLabel": "disease",
     "sortable": true,
     "internalLink": true,
     "chopFieldName": "Disease"
@@ -49,54 +53,63 @@
   {
     "id": "frequencyInOverallDataset",
     "label": "Frequency in overall dataset",
+    "exportLabel": "frequencyInOverallDataset",
     "sortable": true,
     "chopFieldName": "Frequency_in_overall_dataset"
   },
   {
     "id": "totalPrimaryTumorsAlteredOverPrimaryTumorsInDataset",
     "label": "Total primary tumors altered / Primary tumors in dataset",
+    "exportLabel": "totalPrimaryTumorsAlteredOverPrimaryTumorsInDataset",
     "sortable": true,
     "chopFieldName": "Total_primary_tumors_altered_over_Primary_tumors_in_dataset"
   },
   {
     "id": "frequencyInPrimaryTumors",
     "label": "Frequency in primary tumors",
+    "exportLabel": "frequencyInPrimaryTumors",
     "sortable": true,
     "chopFieldName": "Frequency_in_primary_tumors"
   },
   {
     "id": "totalRelapseTumorsAlteredOverRelapseTumorsInDataset",
     "label": "Total relapse tumors altered / Relapse tumors in dataset",
+    "exportLabel": "totalRelapseTumorsAlteredOverRelapseTumorsInDataset",
     "sortable": true,
     "chopFieldName": "Total_relapse_tumors_altered_over_Relapse_tumors_in_dataset"
   },
   {
     "id": "frequencyInRelapseTumors",
     "label": "Frequency in relapse tumors",
+    "exportLabel": "frequencyInRelapseTumors",
     "sortable": true,
     "chopFieldName": "Frequency_in_relapse_tumors"
   },
   {
     "id": "geneFullName",
     "label": "Gene full name",
+    "exportLabel": "geneFullName",
     "sortable": true,
     "chopFieldName": "Gene_full_name"
   },
   {
     "id": "PMTL",
     "label": "PMTL",
+    "exportLabel": "pmtl",
     "sortable": true,
     "chopFieldName": "PMTL"
   },
   {
     "id": "OncoKBCancerGene",
     "label": "OncoKB cancer gene",
+    "exportLabel": "oncoKbCancerGene",
     "sortable": true,
     "chopFieldName": "OncoKB_cancer_gene"
   },
   {
     "id": "OncoKBOncogeneTSG",
     "label": "OncoKB Oncogene|TSG",
+    "exportLabel": "oncoKbOncogeneTsg",
     "sortable": true,
     "chopFieldName": "OncoKB_oncogene_TSG"
   },
@@ -110,6 +123,7 @@
   {
     "id": "MONDO",
     "label": "MONDO",
+    "exportLabel": "mondo",
     "hidden": true,
     "chopFieldName": "MONDO"
   }

--- a/front-end/page_evidence/FusionByGene_Config.json
+++ b/front-end/page_evidence/FusionByGene_Config.json
@@ -2,6 +2,7 @@
   {
     "id": "geneSymbol",
     "label": "Target",
+    "exportLabel": "target",
     "sortable": true,
     "internalLink": true,
     "chopFieldName": "Gene_symbol"

--- a/front-end/page_evidence/FusionByGene_Config.json
+++ b/front-end/page_evidence/FusionByGene_Config.json
@@ -36,6 +36,7 @@
   {
     "id": "totalAlterationsOverNumberPatientsInDataset",
     "label": "Total alterations / Subjects in dataset",
+    "exportLabel": "totalAlterationsOverSubjectsInDataset",
     "sortable": true,
     "chopFieldName": "Total_alterations_Over_Patients_in_dataset"
   },

--- a/front-end/page_evidence/FusionByGene_Config.json
+++ b/front-end/page_evidence/FusionByGene_Config.json
@@ -10,6 +10,7 @@
   {
     "id": "targetFromSourceId",
     "label": "Gene Ensembl ID",
+    "exportLabel": "geneEnsemblId",
     "hidden": true,
     "chopFieldName": "targetFromSourceId"
   },

--- a/front-end/page_evidence/FusionByGene_Config.json
+++ b/front-end/page_evidence/FusionByGene_Config.json
@@ -1,8 +1,7 @@
 [
   {
     "id": "geneSymbol",
-    "label": "Target",
-    "exportLabel": "target",
+    "label": "Gene symbol",
     "sortable": true,
     "internalLink": true,
     "chopFieldName": "Gene_symbol"

--- a/front-end/page_evidence/Fusion_Config.json
+++ b/front-end/page_evidence/Fusion_Config.json
@@ -28,6 +28,7 @@
   {
     "id": "fusionAnno",
     "label": "Fusion annotation",
+    "exportLabel": "fusionAnnotation",
     "sortable": true,
     "chopFieldName": "Fusion_anno"
   },

--- a/front-end/page_evidence/Fusion_Config.json
+++ b/front-end/page_evidence/Fusion_Config.json
@@ -41,6 +41,7 @@
   {
     "id": "annots",
     "label": "Annotations",
+    "exportLabel": "annotations",
     "sortable": true,
     "chopFieldName": "annots"
   },

--- a/front-end/page_evidence/Fusion_Config.json
+++ b/front-end/page_evidence/Fusion_Config.json
@@ -163,6 +163,7 @@
   {
     "id": "diseaseFromSourceMappedId",
     "label": "EFO",
+    "exportLabel": "efo",
     "hidden": true,
     "chopFieldName": "diseaseFromSourceMappedId"
   }

--- a/front-end/page_evidence/Fusion_Config.json
+++ b/front-end/page_evidence/Fusion_Config.json
@@ -66,6 +66,7 @@
   {
     "id": "gene1AAnno",
     "label": "Gene1A annotation",
+    "exportLabel": "gene1AAnnotation",
     "sortable": true,
     "chopFieldName": "Gene1A_anno"
   },

--- a/front-end/page_evidence/Fusion_Config.json
+++ b/front-end/page_evidence/Fusion_Config.json
@@ -114,6 +114,7 @@
   {
     "id": "totalAlterationsOverNumberPatientsInDataset",
     "label": "Total alterations / Subjects in dataset",
+    "exportLabel": "totalAlterationsOverSubjectsInDataset",
     "sortable": true,
     "chopFieldName": "Total_alterations_Over_Patients_in_dataset"
   },

--- a/front-end/page_evidence/Fusion_Config.json
+++ b/front-end/page_evidence/Fusion_Config.json
@@ -14,6 +14,7 @@
   {
     "id": "geneSymbol",
     "label": "Target",
+    "exportLabel": "target",
     "sortable": true,
     "internalLink": true,
     "chopFieldName": "Gene_symbol"

--- a/front-end/page_evidence/Fusion_Config.json
+++ b/front-end/page_evidence/Fusion_Config.json
@@ -87,6 +87,7 @@
   {
     "id": "gene2BAnno",
     "label": "Gene2B annotation",
+    "exportLabel": "gene2BAnnotation",
     "sortable": true,
     "chopFieldName": "Gene2B_anno"
   },

--- a/front-end/page_evidence/Fusion_Config.json
+++ b/front-end/page_evidence/Fusion_Config.json
@@ -80,6 +80,7 @@
   {
     "id": "gene2AAnno",
     "label": "Gene2A annotation",
+    "exportLabel": "gene2AAnnotation",
     "sortable": true,
     "chopFieldName": "Gene2A_anno"
   },

--- a/front-end/page_evidence/Fusion_Config.json
+++ b/front-end/page_evidence/Fusion_Config.json
@@ -13,8 +13,7 @@
   },
   {
     "id": "geneSymbol",
-    "label": "Target",
-    "exportLabel": "target",
+    "label": "Gene symbol",
     "sortable": true,
     "internalLink": true,
     "chopFieldName": "Gene_symbol"

--- a/front-end/page_evidence/Fusion_Config.json
+++ b/front-end/page_evidence/Fusion_Config.json
@@ -73,6 +73,7 @@
   {
     "id": "gene1BAnno",
     "label": "Gene1B annotation",
+    "exportLabel": "gene1BAnnotation",
     "sortable": true,
     "chopFieldName": "Gene1B_anno"
   },

--- a/front-end/page_evidence/Fusion_Config.json
+++ b/front-end/page_evidence/Fusion_Config.json
@@ -88,6 +88,7 @@
   {
     "id": "targetFromSourceId",
     "label": "Gene Ensembl ID",
+    "exportLabel": "geneEnsemblId",
     "hidden": true,
     "chopFieldName": "targetFromSourceId"
   },

--- a/front-end/page_evidence/SnvByGene_Config.json
+++ b/front-end/page_evidence/SnvByGene_Config.json
@@ -2,6 +2,7 @@
   {
     "id": "geneSymbol",
     "label": "Target",
+    "exportLabel": "target",
     "sortable": true,
     "internalLink": true,
     "chopFieldName": "Gene_symbol"

--- a/front-end/page_evidence/SnvByGene_Config.json
+++ b/front-end/page_evidence/SnvByGene_Config.json
@@ -72,6 +72,7 @@
   {
     "id": "totalMutationsOverPatientsInDataset",
     "label": "Total mutations / Subjects in dataset",
+    "exportLabel": "totalMutationsOverSubjectsInDataset",
     "sortable": true,
     "chopFieldName": "Total_mutations_Over_Patients_in_dataset"
   },

--- a/front-end/page_evidence/SnvByGene_Config.json
+++ b/front-end/page_evidence/SnvByGene_Config.json
@@ -122,6 +122,7 @@
   {
     "id": "pedcbioPedotOncoprintPlotURL",
     "label": "PedcBio PedOT oncoprint plot",
+    "exportLabel": "pedcbioPedotOncoprintPlot",
     "externalLink": true,
     "chopFieldName": "PedcBio_PedOT_oncoprint_plot_URL"
   },

--- a/front-end/page_evidence/SnvByGene_Config.json
+++ b/front-end/page_evidence/SnvByGene_Config.json
@@ -59,6 +59,7 @@
   {
     "id": "targetFromSourceId",
     "label": "Gene Ensembl ID",
+    "exportLabel": "geneEnsemblId",
     "hidden": true,
     "chopFieldName": "targetFromSourceId"
   },

--- a/front-end/page_evidence/SnvByGene_Config.json
+++ b/front-end/page_evidence/SnvByGene_Config.json
@@ -129,6 +129,7 @@
   {
     "id": "pedcbioPedotMutationsPlotURL",
     "label": "PedcBio PedOT mutation plot",
+    "exportLabel": "pedcbioPedotMutationsPlot",
     "externalLink": true,
     "chopFieldName": "PedcBio_PedOT_mutations_plot_URL"
   }

--- a/front-end/page_evidence/SnvByGene_Config.json
+++ b/front-end/page_evidence/SnvByGene_Config.json
@@ -29,6 +29,7 @@
   {
     "id": "diseaseFromSourceMappedId",
     "label": "EFO",
+    "exportLabel": "efo",
     "hidden": true,
     "chopFieldName": "diseaseFromSourceMappedId"
   },

--- a/front-end/page_evidence/SnvByGene_Config.json
+++ b/front-end/page_evidence/SnvByGene_Config.json
@@ -1,8 +1,7 @@
 [
   {
     "id": "geneSymbol",
-    "label": "Target",
-    "exportLabel": "target",
+    "label": "Gene symbol",
     "sortable": true,
     "internalLink": true,
     "chopFieldName": "Gene_symbol"

--- a/front-end/page_evidence/SnvByVariant_Config.json
+++ b/front-end/page_evidence/SnvByVariant_Config.json
@@ -114,6 +114,7 @@
   {
     "id": "totalMutationsOverPatientsInDataset",
     "label": "Total mutations / Subjects in dataset",
+    "exportLabel": "totalMutationsOverSubjectsInDataset",
     "sortable": true,
     "chopFieldName": "Total_mutations_Over_Patients_in_dataset"
   },

--- a/front-end/page_evidence/SnvByVariant_Config.json
+++ b/front-end/page_evidence/SnvByVariant_Config.json
@@ -2,6 +2,7 @@
   {
     "id": "geneSymbol",
     "label": "Target",
+    "exportLabel": "target",
     "sortable": true,
     "internalLink": true,
     "chopFieldName": "Gene_symbol"

--- a/front-end/page_evidence/SnvByVariant_Config.json
+++ b/front-end/page_evidence/SnvByVariant_Config.json
@@ -41,6 +41,7 @@
   {
     "id": "diseaseFromSourceMappedId",
     "label": "EFO",
+    "exportLabel": "efo",
     "hidden": true,
     "chopFieldName": "diseaseFromSourceMappedId"
   },

--- a/front-end/page_evidence/SnvByVariant_Config.json
+++ b/front-end/page_evidence/SnvByVariant_Config.json
@@ -1,8 +1,7 @@
 [
   {
     "id": "geneSymbol",
-    "label": "Target",
-    "exportLabel": "target",
+    "label": "Gene symbol",
     "sortable": true,
     "internalLink": true,
     "chopFieldName": "Gene_symbol"

--- a/front-end/page_evidence/SnvByVariant_Config.json
+++ b/front-end/page_evidence/SnvByVariant_Config.json
@@ -95,6 +95,7 @@
   {
     "id": "targetFromSourceId",
     "label": "Gene Ensembl ID",
+    "exportLabel": "geneEnsemblId",
     "hidden": true,
     "chopFieldName": "targetFromSourceId"
   },

--- a/front-end/page_target/CnvByGene_Config.json
+++ b/front-end/page_target/CnvByGene_Config.json
@@ -103,6 +103,7 @@
   {
     "id": "diseaseFromSourceMappedId",
     "label": "EFO",
+    "exportLabel": "efo",
     "hidden": true,
     "chopFieldName": "diseaseFromSourceMappedId"
   },

--- a/front-end/page_target/CnvByGene_Config.json
+++ b/front-end/page_target/CnvByGene_Config.json
@@ -42,6 +42,7 @@
   {
     "id": "totalAlterationsOverPatientsInDataset",
     "label": "Total alterations / Subjects in dataset",
+    "exportLabel": "totalAlterationsOverSubjectsInDataset",
     "sortable": true,
     "chopFieldName": "Total_alterations_over_Patients_in_dataset"
   },

--- a/front-end/page_target/CnvByGene_Config.json
+++ b/front-end/page_target/CnvByGene_Config.json
@@ -2,6 +2,7 @@
   {
     "id": "geneSymbol",
     "label": "Target",
+    "exportLabel": "target",
     "sortable": true,
     "internalLink": true,
     "chopFieldName": "Gene_symbol"

--- a/front-end/page_target/CnvByGene_Config.json
+++ b/front-end/page_target/CnvByGene_Config.json
@@ -10,6 +10,7 @@
   {
     "id": "targetFromSourceId",
     "label": "Gene Ensembl ID",
+    "exportLabel": "geneEnsemblId",
     "hidden": true,
     "chopFieldName": "targetFromSourceId"
   },

--- a/front-end/page_target/CnvByGene_Config.json
+++ b/front-end/page_target/CnvByGene_Config.json
@@ -1,8 +1,7 @@
 [
   {
     "id": "geneSymbol",
-    "label": "Target",
-    "exportLabel": "target",
+    "label": "Gene symbol",
     "sortable": true,
     "internalLink": true,
     "chopFieldName": "Gene_symbol"

--- a/front-end/page_target/FusionByGene_Config.json
+++ b/front-end/page_target/FusionByGene_Config.json
@@ -2,6 +2,7 @@
   {
     "id": "geneSymbol",
     "label": "Target",
+    "exportLabel": "target",
     "sortable": true,
     "internalLink": true,
     "chopFieldName": "Gene_symbol"

--- a/front-end/page_target/FusionByGene_Config.json
+++ b/front-end/page_target/FusionByGene_Config.json
@@ -36,6 +36,7 @@
   {
     "id": "totalAlterationsOverNumberPatientsInDataset",
     "label": "Total alterations / Subjects in dataset",
+    "exportLabel": "totalAlterationsOverSubjectsInDataset",
     "sortable": true,
     "chopFieldName": "Total_alterations_Over_Patients_in_dataset"
   },

--- a/front-end/page_target/FusionByGene_Config.json
+++ b/front-end/page_target/FusionByGene_Config.json
@@ -10,6 +10,7 @@
   {
     "id": "targetFromSourceId",
     "label": "Gene Ensembl ID",
+    "exportLabel": "geneEnsemblId",
     "hidden": true,
     "chopFieldName": "targetFromSourceId"
   },

--- a/front-end/page_target/FusionByGene_Config.json
+++ b/front-end/page_target/FusionByGene_Config.json
@@ -1,8 +1,7 @@
 [
   {
     "id": "geneSymbol",
-    "label": "Target",
-    "exportLabel": "target",
+    "label": "Gene symbol",
     "sortable": true,
     "internalLink": true,
     "chopFieldName": "Gene_symbol"

--- a/front-end/page_target/Fusion_Config.json
+++ b/front-end/page_target/Fusion_Config.json
@@ -28,6 +28,7 @@
   {
     "id": "fusionAnno",
     "label": "Fusion annotation",
+    "exportLabel": "fusionAnnotation",
     "sortable": true,
     "chopFieldName": "Fusion_anno"
   },

--- a/front-end/page_target/Fusion_Config.json
+++ b/front-end/page_target/Fusion_Config.json
@@ -41,6 +41,7 @@
   {
     "id": "annots",
     "label": "Annotations",
+    "exportLabel": "annotations",
     "sortable": true,
     "chopFieldName": "annots"
   },

--- a/front-end/page_target/Fusion_Config.json
+++ b/front-end/page_target/Fusion_Config.json
@@ -163,6 +163,7 @@
   {
     "id": "diseaseFromSourceMappedId",
     "label": "EFO",
+    "exportLabel": "efo",
     "hidden": true,
     "chopFieldName": "diseaseFromSourceMappedId"
   }

--- a/front-end/page_target/Fusion_Config.json
+++ b/front-end/page_target/Fusion_Config.json
@@ -2,6 +2,7 @@
   {
     "id": "fusionName",
     "label": "Fusion Name",
+    "exportLabel": "target",
     "sortable": true,
     "chopFieldName": "FusionName"
   },

--- a/front-end/page_target/Fusion_Config.json
+++ b/front-end/page_target/Fusion_Config.json
@@ -2,7 +2,6 @@
   {
     "id": "fusionName",
     "label": "Fusion Name",
-    "exportLabel": "target",
     "sortable": true,
     "chopFieldName": "FusionName"
   },

--- a/front-end/page_target/Fusion_Config.json
+++ b/front-end/page_target/Fusion_Config.json
@@ -66,6 +66,7 @@
   {
     "id": "gene1AAnno",
     "label": "Gene1A annotation",
+    "exportLabel": "gene1AAnnotation",
     "sortable": true,
     "chopFieldName": "Gene1A_anno"
   },

--- a/front-end/page_target/Fusion_Config.json
+++ b/front-end/page_target/Fusion_Config.json
@@ -13,7 +13,7 @@
   },
   {
     "id": "geneSymbol",
-    "label": "Target",
+    "label": "Gene symbol",
     "sortable": true,
     "internalLink": true,
     "chopFieldName": "Gene_symbol"

--- a/front-end/page_target/Fusion_Config.json
+++ b/front-end/page_target/Fusion_Config.json
@@ -114,6 +114,7 @@
   {
     "id": "totalAlterationsOverNumberPatientsInDataset",
     "label": "Total alterations / Subjects in dataset",
+    "exportLabel": "totalAlterationsOverSubjectsInDataset",
     "sortable": true,
     "chopFieldName": "Total_alterations_Over_Patients_in_dataset"
   },

--- a/front-end/page_target/Fusion_Config.json
+++ b/front-end/page_target/Fusion_Config.json
@@ -87,6 +87,7 @@
   {
     "id": "gene2BAnno",
     "label": "Gene2B annotation",
+    "exportLabel": "gene2BAnnotation",
     "sortable": true,
     "chopFieldName": "Gene2B_anno"
   },

--- a/front-end/page_target/Fusion_Config.json
+++ b/front-end/page_target/Fusion_Config.json
@@ -80,6 +80,7 @@
   {
     "id": "gene2AAnno",
     "label": "Gene2A annotation",
+    "exportLabel": "gene2AAnnotation",
     "sortable": true,
     "chopFieldName": "Gene2A_anno"
   },

--- a/front-end/page_target/Fusion_Config.json
+++ b/front-end/page_target/Fusion_Config.json
@@ -73,6 +73,7 @@
   {
     "id": "gene1BAnno",
     "label": "Gene1B annotation",
+    "exportLabel": "gene1BAnnotation",
     "sortable": true,
     "chopFieldName": "Gene1B_anno"
   },

--- a/front-end/page_target/Fusion_Config.json
+++ b/front-end/page_target/Fusion_Config.json
@@ -88,6 +88,7 @@
   {
     "id": "targetFromSourceId",
     "label": "Gene Ensembl ID",
+    "exportLabel": "geneEnsemblId",
     "hidden": true,
     "chopFieldName": "targetFromSourceId"
   },

--- a/front-end/page_target/SnvByGene_Config.json
+++ b/front-end/page_target/SnvByGene_Config.json
@@ -129,7 +129,7 @@
   {
     "id": "pedcbioPedotMutationsPlotURL",
     "label": "PedcBio PedOT mutation plot",
-    "exportLabel": "pedcbioPedotMutationsPlot",
+    "exportLabel": "pedcbioPedOtMutationsPlot",
     "externalLink": true,
     "chopFieldName": "PedcBio_PedOT_mutations_plot_URL"
   }

--- a/front-end/page_target/SnvByGene_Config.json
+++ b/front-end/page_target/SnvByGene_Config.json
@@ -2,6 +2,7 @@
   {
     "id": "geneSymbol",
     "label": "Target",
+    "exportLabel": "target",
     "sortable": true,
     "internalLink": true,
     "chopFieldName": "Gene_symbol"

--- a/front-end/page_target/SnvByGene_Config.json
+++ b/front-end/page_target/SnvByGene_Config.json
@@ -72,6 +72,7 @@
   {
     "id": "totalMutationsOverPatientsInDataset",
     "label": "Total mutations / Subjects in dataset",
+    "exportLabel": "totalMutationsOverSubjectsInDataset",
     "sortable": true,
     "chopFieldName": "Total_mutations_Over_Patients_in_dataset"
   },

--- a/front-end/page_target/SnvByGene_Config.json
+++ b/front-end/page_target/SnvByGene_Config.json
@@ -122,6 +122,7 @@
   {
     "id": "pedcbioPedotOncoprintPlotURL",
     "label": "PedcBio PedOT oncoprint plot",
+    "exportLabel": "pedcbioPedotOncoprintPlot",
     "externalLink": true,
     "chopFieldName": "PedcBio_PedOT_oncoprint_plot_URL"
   },

--- a/front-end/page_target/SnvByGene_Config.json
+++ b/front-end/page_target/SnvByGene_Config.json
@@ -59,6 +59,7 @@
   {
     "id": "targetFromSourceId",
     "label": "Gene Ensembl ID",
+    "exportLabel": "geneEnsemblId",
     "hidden": true,
     "chopFieldName": "targetFromSourceId"
   },

--- a/front-end/page_target/SnvByGene_Config.json
+++ b/front-end/page_target/SnvByGene_Config.json
@@ -129,6 +129,7 @@
   {
     "id": "pedcbioPedotMutationsPlotURL",
     "label": "PedcBio PedOT mutation plot",
+    "exportLabel": "pedcbioPedotMutationsPlot",
     "externalLink": true,
     "chopFieldName": "PedcBio_PedOT_mutations_plot_URL"
   }

--- a/front-end/page_target/SnvByGene_Config.json
+++ b/front-end/page_target/SnvByGene_Config.json
@@ -122,7 +122,7 @@
   {
     "id": "pedcbioPedotOncoprintPlotURL",
     "label": "PedcBio PedOT oncoprint plot",
-    "exportLabel": "pedcbioPedotOncoprintPlot",
+    "exportLabel": "pedcbioPedOtOncoprintPlot",
     "externalLink": true,
     "chopFieldName": "PedcBio_PedOT_oncoprint_plot_URL"
   },

--- a/front-end/page_target/SnvByGene_Config.json
+++ b/front-end/page_target/SnvByGene_Config.json
@@ -29,6 +29,7 @@
   {
     "id": "diseaseFromSourceMappedId",
     "label": "EFO",
+    "exportLabel": "efo",
     "hidden": true,
     "chopFieldName": "diseaseFromSourceMappedId"
   },

--- a/front-end/page_target/SnvByGene_Config.json
+++ b/front-end/page_target/SnvByGene_Config.json
@@ -1,8 +1,7 @@
 [
   {
     "id": "geneSymbol",
-    "label": "Target",
-    "exportLabel": "target",
+    "label": "Gene symbol",
     "sortable": true,
     "internalLink": true,
     "chopFieldName": "Gene_symbol"

--- a/front-end/page_target/SnvByVariant_Config.json
+++ b/front-end/page_target/SnvByVariant_Config.json
@@ -114,6 +114,7 @@
   {
     "id": "totalMutationsOverPatientsInDataset",
     "label": "Total mutations / Subjects in dataset",
+    "exportLabel": "totalMutationsOverSubjectsInDataset",
     "sortable": true,
     "chopFieldName": "Total_mutations_Over_Patients_in_dataset"
   },

--- a/front-end/page_target/SnvByVariant_Config.json
+++ b/front-end/page_target/SnvByVariant_Config.json
@@ -2,6 +2,7 @@
   {
     "id": "geneSymbol",
     "label": "Target",
+    "exportLabel": "target",
     "sortable": true,
     "internalLink": true,
     "chopFieldName": "Gene_symbol"

--- a/front-end/page_target/SnvByVariant_Config.json
+++ b/front-end/page_target/SnvByVariant_Config.json
@@ -41,6 +41,7 @@
   {
     "id": "diseaseFromSourceMappedId",
     "label": "EFO",
+    "exportLabel": "efo",
     "hidden": true,
     "chopFieldName": "diseaseFromSourceMappedId"
   },

--- a/front-end/page_target/SnvByVariant_Config.json
+++ b/front-end/page_target/SnvByVariant_Config.json
@@ -1,8 +1,7 @@
 [
   {
     "id": "geneSymbol",
-    "label": "Target",
-    "exportLabel": "target",
+    "label": "Gene symbol",
     "sortable": true,
     "internalLink": true,
     "chopFieldName": "Gene_symbol"

--- a/front-end/page_target/SnvByVariant_Config.json
+++ b/front-end/page_target/SnvByVariant_Config.json
@@ -95,6 +95,7 @@
   {
     "id": "targetFromSourceId",
     "label": "Gene Ensembl ID",
+    "exportLabel": "geneEnsemblId",
     "hidden": true,
     "chopFieldName": "targetFromSourceId"
   },


### PR DESCRIPTION
In this PR, “exportLabel” is added as a property to all of the column object under page_evidence/CnvByGene_Config.json to demonstrate how it works.

With this implementation: 
“exportLabel” value will be used as column name shown on the exported/downloaded file header. If "exportLabel" is not present, camelCase value of “id” field will be used. A camelCase will also be apply to “exportLabel” value.

As we can see from the second commit, the “id” and “exportLabel” value can be same. In this case, not including exportLabel might help to reduce the duplication. The first commit is an example of where “exportLabel” is needed, whereas second commit is an example of where “exportLabel” is unneeded. 

I hope this clarify the usage of "exportLabel" 👍 