### PR TITLE
Edit configs for internal consistency

### DIFF
--- a/front-end/page_evidence/FusionByGene_Config.json
+++ b/front-end/page_evidence/FusionByGene_Config.json
@@ -68,5 +68,18 @@
     "label": "Frequency in relapse tumors",
     "sortable": true,
     "chopFieldName": "Frequency_in_relapse_tumors"
+  },
+  {
+    "id": "MONDO",
+    "label": "MONDO",
+    "hidden": true,
+    "chopFieldName": "MONDO"
+  },
+  {
+    "id": "diseaseFromSourceMappedId",
+    "label": "EFO",
+    "exportLabel": "efo",
+    "hidden": true,
+    "chopFieldName": "diseaseFromSourceMappedId"
   }
 ]

--- a/front-end/page_target/FusionByGene_Config.json
+++ b/front-end/page_target/FusionByGene_Config.json
@@ -68,5 +68,18 @@
     "label": "Frequency in relapse tumors",
     "sortable": true,
     "chopFieldName": "Frequency_in_relapse_tumors"
+  },
+  {
+    "id": "MONDO",
+    "label": "MONDO",
+    "hidden": true,
+    "chopFieldName": "MONDO"
+  },
+  {
+    "id": "diseaseFromSourceMappedId",
+    "label": "EFO",
+    "exportLabel": "efo",
+    "hidden": true,
+    "chopFieldName": "diseaseFromSourceMappedId"
   }
 ]

--- a/front-end/page_target/SnvByGene_Config.json
+++ b/front-end/page_target/SnvByGene_Config.json
@@ -121,14 +121,14 @@
   {
     "id": "pedcbioPedotOncoprintPlotURL",
     "label": "PedcBio PedOT oncoprint plot",
-    "exportLabel": "pedcbioPedOtOncoprintPlot",
+    "exportLabel": "pedcbioPedotOncoprintPlot",
     "externalLink": true,
     "chopFieldName": "PedcBio_PedOT_oncoprint_plot_URL"
   },
   {
     "id": "pedcbioPedotMutationsPlotURL",
     "label": "PedcBio PedOT mutation plot",
-    "exportLabel": "pedcbioPedOtMutationsPlot",
+    "exportLabel": "pedcbioPedotMutationsPlot",
     "externalLink": true,
     "chopFieldName": "PedcBio_PedOT_mutations_plot_URL"
   }


### PR DESCRIPTION
- Lower casing of `Ot` in PedcBioPortal exportLabels in page_target\SnvByGene
- Add `MONDO` and `diseaseFromSourceMappedId` exportLabels to page_evidence\FusionByGene and page_target\FusionByGene (use placement of those objects in the Fusion configs as guide)