### PR TITLE
Gene Expression Config Files

### DIFF
--- a/front-end/page_evidence/GeneExpression_Config.json
+++ b/front-end/page_evidence/GeneExpression_Config.json
@@ -1,0 +1,87 @@
+[
+  {
+    "id": "x_labels",
+    "exportLabel": "xLabels",
+    "chopFieldName": "x_labels"
+  },
+  {
+    "id": "Gene_Ensembl_ID",
+    "exportLabel": "geneEnsemblId",
+    "chopFieldName": "Gene_Ensembl_ID"
+  },
+  {
+    "id": "Gene_symbol",
+    "exportLabel": "geneSymbol",
+    "chopFieldName": "Gene_symbol"
+  },
+  {
+    "id": "PMTL",
+    "exportLabel": "pmtl",
+    "chopFieldName": "PMTL"
+  },
+  {
+    "id": "Dataset",
+    "exportLabel": "dataset",
+    "chopFieldName": "Dataset"
+  },
+  {
+    "id": "Disease",
+    "exportLabel": "disease",
+    "chopFieldName": "Disease"
+  },
+  {
+    "id": "GTEx_tissue_subgroup",
+    "exportLabel": "gtexTissueSubgroup",
+    "chopFieldName": "GTEx_tissue_subgroup"
+  },
+  {
+    "id": "EFO",
+    "exportLabel": "efo",
+    "chopFieldName": "EFO"
+  },
+  {
+    "id": "MONDO",
+    "exportLabel": "mondo",
+    "chopFieldName": "MONDO"
+  },
+  {
+    "id": "GTEx_tissue_subgroup_UBERON",
+    "exportLabel": "gtexTissueSubgroupUberon",
+    "chopFieldName": "GTEx_tissue_subgroup_UBERON"
+  },
+  {
+    "id": "TPM_mean",
+    "exportLabel": "tpmMean",
+    "chopFieldName": "TPM_mean"
+  },
+  {
+    "id": "TPM_sd",
+    "exportLabel": "tpmSd",
+    "chopFieldName": "TPM_sd"
+  },
+  {
+    "id": "TPM_min",
+    "exportLabel": "tpmMin",
+    "chopFieldName": "TPM_min"
+  },
+  {
+    "id": "TPM_25th_percentile",
+    "exportLabel": "tpm25thPercentile",
+    "chopFieldName": "TPM_25th_percentile"
+  },
+  {
+    "id": "TPM_median",
+    "exportLabel": "tpmMedian",
+    "chopFieldName": "TPM_median"
+  },
+  {
+    "id": "TPM_75th_percentile",
+    "exportLabel": "tpm75thPercentile",
+    "chopFieldName": "TPM_75th_percentile"
+  },
+  {
+    "id": "TPM_max",
+    "exportLabel": "tpmMax",
+    "chopFieldName": "TPM_max"
+  }
+]

--- a/front-end/page_target/GeneExpression_Config.json
+++ b/front-end/page_target/GeneExpression_Config.json
@@ -1,0 +1,87 @@
+[
+  {
+    "id": "x_labels",
+    "exportLabel": "xLabels",
+    "chopFieldName": "x_labels"
+  },
+  {
+    "id": "Gene_Ensembl_ID",
+    "exportLabel": "geneEnsemblId",
+    "chopFieldName": "Gene_Ensembl_ID"
+  },
+  {
+    "id": "Gene_symbol",
+    "exportLabel": "geneSymbol",
+    "chopFieldName": "Gene_symbol"
+  },
+  {
+    "id": "PMTL",
+    "exportLabel": "pmtl",
+    "chopFieldName": "PMTL"
+  },
+  {
+    "id": "Dataset",
+    "exportLabel": "dataset",
+    "chopFieldName": "Dataset"
+  },
+  {
+    "id": "Disease",
+    "exportLabel": "disease",
+    "chopFieldName": "Disease"
+  },
+  {
+    "id": "GTEx_tissue_subgroup",
+    "exportLabel": "gtexTissueSubgroup",
+    "chopFieldName": "GTEx_tissue_subgroup"
+  },
+  {
+    "id": "EFO",
+    "exportLabel": "efo",
+    "chopFieldName": "EFO"
+  },
+  {
+    "id": "MONDO",
+    "exportLabel": "mondo",
+    "chopFieldName": "MONDO"
+  },
+  {
+    "id": "GTEx_tissue_subgroup_UBERON",
+    "exportLabel": "gtexTissueSubgroupUberon",
+    "chopFieldName": "GTEx_tissue_subgroup_UBERON"
+  },
+  {
+    "id": "TPM_mean",
+    "exportLabel": "tpmMean",
+    "chopFieldName": "TPM_mean"
+  },
+  {
+    "id": "TPM_sd",
+    "exportLabel": "tpmSd",
+    "chopFieldName": "TPM_sd"
+  },
+  {
+    "id": "TPM_min",
+    "exportLabel": "tpmMin",
+    "chopFieldName": "TPM_min"
+  },
+  {
+    "id": "TPM_25th_percentile",
+    "exportLabel": "tpm25thPercentile",
+    "chopFieldName": "TPM_25th_percentile"
+  },
+  {
+    "id": "TPM_median",
+    "exportLabel": "tpmMedian",
+    "chopFieldName": "TPM_median"
+  },
+  {
+    "id": "TPM_75th_percentile",
+    "exportLabel": "tpm75thPercentile",
+    "chopFieldName": "TPM_75th_percentile"
+  },
+  {
+    "id": "TPM_max",
+    "exportLabel": "tpmMax",
+    "chopFieldName": "TPM_max"
+  }
+]


### PR DESCRIPTION
In this PR:
-	Two new config file under page_evidence and page_target with a name of GeneExpression_Config.json has been created for “OpenPedCan Gene Expression” widget. 

-	As of now, “OpenPedCan Gene Expression” widget has plots and data download so the Config file will only be used to configure the data that will be downloaded.