### PR TITLE
NonSortable Column

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,15 +46,15 @@ Example URLs to MTP pages: <br>
   Target Page (page_target):
   <ul>
     <li> https://ppdc-otp-qa.bento-tools.org/target/ENSG00000171094 </li>
-    <li> https://ppdc-otp-dev.bento-tools.org/target/ENSG00000097007 </li>
-    <li> https://ppdc-otp-dev.bento-tools.org/target/ENSG00000157764 </li>
+    <li> https://ppdc-otp-qa.bento-tools.org/target/ENSG00000097007 </li>
+    <li> https://ppdc-otp-qa.bento-tools.org/target/ENSG00000157764 </li>
   </ul>
 
   <br>
   Evidence Page (page_evidence):
   <ul>
-    <li> https://ppdc-otp-dev.bento-tools.org/evidence/ENSG00000171094/EFO_0000621 </li>
-    <li> https://ppdc-otp-dev.bento-tools.org/evidence/ENSG00000171094/EFO_0000616 </li>
-    <li> https://ppdc-otp-dev.bento-tools.org/evidence/ENSG00000157764/EFO_0000616 </li>
+    <li> https://ppdc-otp-qa.bento-tools.org/evidence/ENSG00000171094/EFO_0000621 </li>
+    <li> https://ppdc-otp-qa.bento-tools.org/evidence/ENSG00000171094/EFO_0000616 </li>
+    <li> https://ppdc-otp-qa.bento-tools.org/evidence/ENSG00000157764/EFO_0000616 </li>
   </ul>
 </ul>

--- a/README.md
+++ b/README.md
@@ -38,3 +38,23 @@ For every key in the JSON object, provide a detailed description by creating the
 
   <b>chopFieldName</b>: The ID name used to describe this column from CHoP source file.
 </p>
+
+<br><hr><br>
+
+Example URLs to MTP pages: <br>
+<ul>
+  Target Page (page_target):
+  <ul>
+    <li> https://ppdc-otp-qa.bento-tools.org/target/ENSG00000171094 </li>
+    <li> https://ppdc-otp-dev.bento-tools.org/target/ENSG00000097007 </li>
+    <li> https://ppdc-otp-dev.bento-tools.org/target/ENSG00000157764 </li>
+  </ul>
+
+  <br>
+  Evidence Page (page_evidence):
+  <ul>
+    <li> https://ppdc-otp-dev.bento-tools.org/evidence/ENSG00000171094/EFO_0000621 </li>
+    <li> https://ppdc-otp-dev.bento-tools.org/evidence/ENSG00000171094/EFO_0000616 </li>
+    <li> https://ppdc-otp-dev.bento-tools.org/evidence/ENSG00000157764/EFO_0000616 </li>
+  </ul>
+</ul>

--- a/front-end/page_evidence/CnvByGene_Config.json
+++ b/front-end/page_evidence/CnvByGene_Config.json
@@ -2,7 +2,7 @@
   {
     "id": "geneSymbol",
     "label": "Gene symbol",
-    "sortable": true,
+    "sortable": false,
     "internalLink": true,
     "chopFieldName": "Gene_symbol"
   },

--- a/front-end/page_evidence/CnvByGene_Config.json
+++ b/front-end/page_evidence/CnvByGene_Config.json
@@ -95,7 +95,7 @@
     "id": "PMTL",
     "label": "PMTL",
     "exportLabel": "pmtl",
-    "sortable": true,
+    "sortable": false,
     "chopFieldName": "PMTL"
   },
   {

--- a/front-end/page_evidence/CnvByGene_Config.json
+++ b/front-end/page_evidence/CnvByGene_Config.json
@@ -102,7 +102,7 @@
     "id": "OncoKBCancerGene",
     "label": "OncoKB cancer gene",
     "exportLabel": "oncoKbCancerGene",
-    "sortable": true,
+    "sortable": false,
     "chopFieldName": "OncoKB_cancer_gene"
   },
   {

--- a/front-end/page_evidence/CnvByGene_Config.json
+++ b/front-end/page_evidence/CnvByGene_Config.json
@@ -109,7 +109,7 @@
     "id": "OncoKBOncogeneTSG",
     "label": "OncoKB Oncogene|TSG",
     "exportLabel": "oncoKbOncogeneTsg",
-    "sortable": true,
+    "sortable": false,
     "chopFieldName": "OncoKB_oncogene_TSG"
   },
   {

--- a/front-end/page_evidence/CnvByGene_Config.json
+++ b/front-end/page_evidence/CnvByGene_Config.json
@@ -88,7 +88,7 @@
     "id": "geneFullName",
     "label": "Gene full name",
     "exportLabel": "geneFullName",
-    "sortable": true,
+    "sortable": false,
     "chopFieldName": "Gene_full_name"
   },
   {

--- a/front-end/page_evidence/FusionByGene_Config.json
+++ b/front-end/page_evidence/FusionByGene_Config.json
@@ -2,7 +2,7 @@
   {
     "id": "geneSymbol",
     "label": "Gene symbol",
-    "sortable": true,
+    "sortable": false,
     "internalLink": true,
     "chopFieldName": "Gene_symbol"
   },

--- a/front-end/page_evidence/FusionByGene_Config.json
+++ b/front-end/page_evidence/FusionByGene_Config.json
@@ -23,7 +23,7 @@
   {
     "id": "PMTL",
     "label": "PMTL",
-    "sortable": true,
+    "sortable": false,
     "chopFieldName": "PMTL"
   },
   {

--- a/front-end/page_evidence/Fusion_Config.json
+++ b/front-end/page_evidence/Fusion_Config.json
@@ -14,7 +14,7 @@
   {
     "id": "geneSymbol",
     "label": "Gene symbol",
-    "sortable": true,
+    "sortable": false,
     "internalLink": true,
     "chopFieldName": "Gene_symbol"
   },

--- a/front-end/page_evidence/Fusion_Config.json
+++ b/front-end/page_evidence/Fusion_Config.json
@@ -107,7 +107,7 @@
   {
     "id": "PMTL",
     "label": "PMTL",
-    "sortable": true,
+    "sortable": false,
     "chopFieldName": "PMTL"
   },
   {

--- a/front-end/page_evidence/SnvByGene_Config.json
+++ b/front-end/page_evidence/SnvByGene_Config.json
@@ -2,7 +2,7 @@
   {
     "id": "geneSymbol",
     "label": "Gene symbol",
-    "sortable": true,
+    "sortable": false,
     "internalLink": true,
     "chopFieldName": "Gene_symbol"
   },

--- a/front-end/page_evidence/SnvByGene_Config.json
+++ b/front-end/page_evidence/SnvByGene_Config.json
@@ -115,7 +115,7 @@
   {
     "id": "OncoKBOncogeneTSG",
     "label": "OncoKB Oncogene|TSG",
-    "sortable": true,
+    "sortable": false,
     "chopFieldName": "OncoKB_oncogene_TSG"
   },
   {

--- a/front-end/page_evidence/SnvByGene_Config.json
+++ b/front-end/page_evidence/SnvByGene_Config.json
@@ -9,7 +9,7 @@
   {
     "id": "PMTL",
     "label": "PMTL",
-    "sortable": true,
+    "sortable": false,
     "chopFieldName": "PMTL"
   },
   {

--- a/front-end/page_evidence/SnvByGene_Config.json
+++ b/front-end/page_evidence/SnvByGene_Config.json
@@ -47,7 +47,7 @@
   {
     "id": "geneType",
     "label": "Gene type",
-    "sortable": true,
+    "sortable": false,
     "chopFieldName": "Gene_type"
   },
   {

--- a/front-end/page_evidence/SnvByGene_Config.json
+++ b/front-end/page_evidence/SnvByGene_Config.json
@@ -53,7 +53,7 @@
   {
     "id": "proteinRefseqId",
     "label": "Protein RefSeq ID",
-    "sortable": true,
+    "sortable": false,
     "chopFieldName": "Protein_RefSeq_ID"
   },
   {

--- a/front-end/page_evidence/SnvByGene_Config.json
+++ b/front-end/page_evidence/SnvByGene_Config.json
@@ -41,7 +41,7 @@
   {
     "id": "geneFullName",
     "label": "Gene full name",
-    "sortable": true,
+    "sortable": false,
     "chopFieldName": "Gene_full_name"
   },
   {

--- a/front-end/page_evidence/SnvByGene_Config.json
+++ b/front-end/page_evidence/SnvByGene_Config.json
@@ -109,7 +109,7 @@
   {
     "id": "OncoKBCancerGene",
     "label": "OncoKB cancer gene",
-    "sortable": true,
+    "sortable": false,
     "chopFieldName": "OncoKB_cancer_gene"
   },
   {

--- a/front-end/page_evidence/SnvByVariant_Config.json
+++ b/front-end/page_evidence/SnvByVariant_Config.json
@@ -2,7 +2,7 @@
   {
     "id": "geneSymbol",
     "label": "Gene symbol",
-    "sortable": true,
+    "sortable": false,
     "internalLink": true,
     "chopFieldName": "Gene_symbol"
   },

--- a/front-end/page_evidence/SnvByVariant_Config.json
+++ b/front-end/page_evidence/SnvByVariant_Config.json
@@ -157,7 +157,7 @@
   {
     "id": "OncoKBCancerGene",
     "label": "OncoKB cancer gene",
-    "sortable": true,
+    "sortable": false,
     "chopFieldName": "OncoKB_cancer_gene"
   },
   {

--- a/front-end/page_evidence/SnvByVariant_Config.json
+++ b/front-end/page_evidence/SnvByVariant_Config.json
@@ -21,7 +21,7 @@
   {
     "id": "PMTL",
     "label": "PMTL",
-    "sortable": true,
+    "sortable": false,
     "chopFieldName": "PMTL"
   },
   {

--- a/front-end/page_evidence/SnvByVariant_Config.json
+++ b/front-end/page_evidence/SnvByVariant_Config.json
@@ -89,7 +89,7 @@
   {
     "id": "geneFullName",
     "label": "Gene full name",
-    "sortable": true,
+    "sortable": false,
     "chopFieldName": "Gene_full_name"
   },
   {

--- a/front-end/page_evidence/SnvByVariant_Config.json
+++ b/front-end/page_evidence/SnvByVariant_Config.json
@@ -102,7 +102,7 @@
   {
     "id": "proteinRefseqId",
     "label": "Protein RefSeq ID",
-    "sortable": true,
+    "sortable": false,
     "chopFieldName": "Protein_RefSeq_ID"
   },
   {

--- a/front-end/page_evidence/SnvByVariant_Config.json
+++ b/front-end/page_evidence/SnvByVariant_Config.json
@@ -163,7 +163,7 @@
   {
     "id": "OncoKBOncogeneTSG",
     "label": "OncoKB Oncogene|TSG",
-    "sortable": true,
+    "sortable": false,
     "chopFieldName": "OncoKB_oncogene_TSG"
   }
 ]

--- a/front-end/page_target/CnvByGene_Config.json
+++ b/front-end/page_target/CnvByGene_Config.json
@@ -2,7 +2,7 @@
   {
     "id": "geneSymbol",
     "label": "Gene symbol",
-    "sortable": true,
+    "sortable": false,
     "internalLink": true,
     "chopFieldName": "Gene_symbol"
   },

--- a/front-end/page_target/CnvByGene_Config.json
+++ b/front-end/page_target/CnvByGene_Config.json
@@ -84,7 +84,7 @@
   {
     "id": "PMTL",
     "label": "PMTL",
-    "sortable": true,
+    "sortable": false,
     "chopFieldName": "PMTL"
   },
   {

--- a/front-end/page_target/CnvByGene_Config.json
+++ b/front-end/page_target/CnvByGene_Config.json
@@ -78,7 +78,7 @@
   {
     "id": "geneFullName",
     "label": "Gene full name",
-    "sortable": true,
+    "sortable": false,
     "chopFieldName": "Gene_full_name"
   },
   {

--- a/front-end/page_target/CnvByGene_Config.json
+++ b/front-end/page_target/CnvByGene_Config.json
@@ -90,7 +90,7 @@
   {
     "id": "OncoKBCancerGene",
     "label": "OncoKB cancer gene",
-    "sortable": true,
+    "sortable": false,
     "chopFieldName": "OncoKB_cancer_gene"
   },
   {

--- a/front-end/page_target/CnvByGene_Config.json
+++ b/front-end/page_target/CnvByGene_Config.json
@@ -96,7 +96,7 @@
   {
     "id": "OncoKBOncogeneTSG",
     "label": "OncoKB Oncogene|TSG",
-    "sortable": true,
+    "sortable": false,
     "chopFieldName": "OncoKB_oncogene_TSG"
   },
   {

--- a/front-end/page_target/FusionByGene_Config.json
+++ b/front-end/page_target/FusionByGene_Config.json
@@ -2,7 +2,7 @@
   {
     "id": "geneSymbol",
     "label": "Gene symbol",
-    "sortable": true,
+    "sortable": false,
     "internalLink": true,
     "chopFieldName": "Gene_symbol"
   },

--- a/front-end/page_target/FusionByGene_Config.json
+++ b/front-end/page_target/FusionByGene_Config.json
@@ -23,7 +23,7 @@
   {
     "id": "PMTL",
     "label": "PMTL",
-    "sortable": true,
+    "sortable": false,
     "chopFieldName": "PMTL"
   },
   {

--- a/front-end/page_target/Fusion_Config.json
+++ b/front-end/page_target/Fusion_Config.json
@@ -14,7 +14,7 @@
   {
     "id": "geneSymbol",
     "label": "Gene symbol",
-    "sortable": true,
+    "sortable": false,
     "internalLink": true,
     "chopFieldName": "Gene_symbol"
   },

--- a/front-end/page_target/Fusion_Config.json
+++ b/front-end/page_target/Fusion_Config.json
@@ -107,7 +107,7 @@
   {
     "id": "PMTL",
     "label": "PMTL",
-    "sortable": true,
+    "sortable": false,
     "chopFieldName": "PMTL"
   },
   {

--- a/front-end/page_target/SnvByGene_Config.json
+++ b/front-end/page_target/SnvByGene_Config.json
@@ -2,7 +2,7 @@
   {
     "id": "geneSymbol",
     "label": "Gene symbol",
-    "sortable": true,
+    "sortable": false,
     "internalLink": true,
     "chopFieldName": "Gene_symbol"
   },

--- a/front-end/page_target/SnvByGene_Config.json
+++ b/front-end/page_target/SnvByGene_Config.json
@@ -115,7 +115,7 @@
   {
     "id": "OncoKBOncogeneTSG",
     "label": "OncoKB Oncogene|TSG",
-    "sortable": true,
+    "sortable": false,
     "chopFieldName": "OncoKB_oncogene_TSG"
   },
   {

--- a/front-end/page_target/SnvByGene_Config.json
+++ b/front-end/page_target/SnvByGene_Config.json
@@ -9,7 +9,7 @@
   {
     "id": "PMTL",
     "label": "PMTL",
-    "sortable": true,
+    "sortable": false,
     "chopFieldName": "PMTL"
   },
   {

--- a/front-end/page_target/SnvByGene_Config.json
+++ b/front-end/page_target/SnvByGene_Config.json
@@ -47,7 +47,7 @@
   {
     "id": "geneType",
     "label": "Gene type",
-    "sortable": true,
+    "sortable": false,
     "chopFieldName": "Gene_type"
   },
   {

--- a/front-end/page_target/SnvByGene_Config.json
+++ b/front-end/page_target/SnvByGene_Config.json
@@ -53,7 +53,7 @@
   {
     "id": "proteinRefseqId",
     "label": "Protein RefSeq ID",
-    "sortable": true,
+    "sortable": false,
     "chopFieldName": "Protein_RefSeq_ID"
   },
   {

--- a/front-end/page_target/SnvByGene_Config.json
+++ b/front-end/page_target/SnvByGene_Config.json
@@ -41,7 +41,7 @@
   {
     "id": "geneFullName",
     "label": "Gene full name",
-    "sortable": true,
+    "sortable": false,
     "chopFieldName": "Gene_full_name"
   },
   {

--- a/front-end/page_target/SnvByGene_Config.json
+++ b/front-end/page_target/SnvByGene_Config.json
@@ -109,7 +109,7 @@
   {
     "id": "OncoKBCancerGene",
     "label": "OncoKB cancer gene",
-    "sortable": true,
+    "sortable": false,
     "chopFieldName": "OncoKB_cancer_gene"
   },
   {

--- a/front-end/page_target/SnvByVariant_Config.json
+++ b/front-end/page_target/SnvByVariant_Config.json
@@ -2,7 +2,7 @@
   {
     "id": "geneSymbol",
     "label": "Gene symbol",
-    "sortable": true,
+    "sortable": false,
     "internalLink": true,
     "chopFieldName": "Gene_symbol"
   },

--- a/front-end/page_target/SnvByVariant_Config.json
+++ b/front-end/page_target/SnvByVariant_Config.json
@@ -157,7 +157,7 @@
   {
     "id": "OncoKBCancerGene",
     "label": "OncoKB cancer gene",
-    "sortable": true,
+    "sortable": false,
     "chopFieldName": "OncoKB_cancer_gene"
   },
   {

--- a/front-end/page_target/SnvByVariant_Config.json
+++ b/front-end/page_target/SnvByVariant_Config.json
@@ -21,7 +21,7 @@
   {
     "id": "PMTL",
     "label": "PMTL",
-    "sortable": true,
+    "sortable": false,
     "chopFieldName": "PMTL"
   },
   {

--- a/front-end/page_target/SnvByVariant_Config.json
+++ b/front-end/page_target/SnvByVariant_Config.json
@@ -89,7 +89,7 @@
   {
     "id": "geneFullName",
     "label": "Gene full name",
-    "sortable": true,
+    "sortable": false,
     "chopFieldName": "Gene_full_name"
   },
   {

--- a/front-end/page_target/SnvByVariant_Config.json
+++ b/front-end/page_target/SnvByVariant_Config.json
@@ -102,7 +102,7 @@
   {
     "id": "proteinRefseqId",
     "label": "Protein RefSeq ID",
-    "sortable": true,
+    "sortable": false,
     "chopFieldName": "Protein_RefSeq_ID"
   },
   {

--- a/front-end/page_target/SnvByVariant_Config.json
+++ b/front-end/page_target/SnvByVariant_Config.json
@@ -163,7 +163,7 @@
   {
     "id": "OncoKBOncogeneTSG",
     "label": "OncoKB Oncogene|TSG",
-    "sortable": true,
+    "sortable": false,
     "chopFieldName": "OncoKB_oncogene_TSG"
   }
 ]


### PR DESCRIPTION
In this PR:

-	The Columns that have same value across rows have been identify and changed their sorting functionality(`sortable`) from true to false. 
-	By Default, all column under OpenPedCan Somatic Alterations has been `sortable: true`, with this PR only columns with different value across the rows can have the sorting functionality.

The list below is the summary of the column’s that will no longer have the sorting functionality `sortable: false` under Target and Evidence page:

```

All Table (“SNV by Gene”, “SNV by Variant”, “CNV by Gene”, "Fusion by Gene" and "Fusion")
- Gene symbol
- PMTL

Across “SNV by Gene”, “SNV by Variant”, and “CNV by Gene”
- Gene full name
- OncoKB cancer gene
- OncoKB oncogene|TSG

Only in “SNV by Gene”
- Protein RefSeq ID
- Gene type

Only in “SNV by Variant”
- Protein RefSeq ID
```


